### PR TITLE
feat: enhance calculator ui

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,17 +5,19 @@
   function calcRCompraMax(m_pct, r_cobro, o_pct){ const m=m_pct/100, o=o_pct/100; const denom=1-m+o; if(denom<=0) return NaN; return r_cobro/denom; }
   function calcOpMarginPct(m_pct, r_cobro, r_compra){ const m=m_pct/100; return (r_cobro/r_compra - (1-m)) * 100; }
   $('btnCalcular').addEventListener('click', ()=>{
-    const m=parseNum($('margen').value), r=parseNum($('cobro').value), o=parseNum($('operativo').value);
-    if(!isFinite(m)||!isFinite(r)||!isFinite(o)||r<=0||m<0||m>=100||o<0||o>=100){ $('resultado').innerHTML='⚠️ Revisa los valores (números válidos, % entre 0–100, tasa > 0).'; $('resultado').classList.remove('muted'); return; }
-    if(m + 1e-12 < o){ $('resultado').innerHTML=`❌ Imposible: margen bruto ${m.toFixed(2)}% < mínimo operativo ${o.toFixed(2)}%.`; $('resultado').classList.remove('muted'); return; }
-    const rmax=calcRCompraMax(m,r,o); if(!isFinite(rmax)){ $('resultado').innerHTML='⚠️ Parámetros inválidos (1 - m + o ≤ 0).'; $('resultado').classList.remove('muted'); return; }
-    $('resultado').innerHTML=`Tasa <b>MÁXIMA</b> de <b>COMPRA</b>: <b>${fmt(rmax)} Bs/USD</b><br>Si compras al mismo tipo que cobras (${fmt(r)}), tu margen operativo = margen bruto: ${m.toFixed(2)}%.`; $('resultado').classList.remove('muted');
+    const m=parseNum($('margen').value), r=parseNum($('cobro').value), o=parseNum($('operativo').value), res=$('resultado');
+    res.classList.remove('muted','success','error');
+    if(!isFinite(m)||!isFinite(r)||!isFinite(o)||r<=0||m<0||m>=100||o<0||o>=100){ res.innerHTML='⚠️ Revisa los valores (números válidos, % entre 0–100, tasa > 0).'; res.classList.add('error'); return; }
+    if(m + 1e-12 < o){ res.innerHTML=`❌ Imposible: margen bruto ${m.toFixed(2)}% < mínimo operativo ${o.toFixed(2)}%.`; res.classList.add('error'); return; }
+    const rmax=calcRCompraMax(m,r,o); if(!isFinite(rmax)){ res.innerHTML='⚠️ Parámetros inválidos (1 - m + o ≤ 0).'; res.classList.add('error'); return; }
+    res.innerHTML=`Tasa <b>MÁXIMA</b> de <b>COMPRA</b>: <b>${fmt(rmax)} Bs/USD</b><br>Si compras al mismo tipo que cobras (${fmt(r)}), tu margen operativo = margen bruto: ${m.toFixed(2)}%.`; res.classList.add('success');
   });
   $('btnEvaluar').addEventListener('click', ()=>{
-    const m=parseNum($('margen').value), r=parseNum($('cobro').value), o=parseNum($('operativo').value), re=parseNum($('eval').value);
-    if(!isFinite(re)||re<=0){ $('evalSalida').innerHTML='⚠️ Ingresa una tasa de compra válida.'; $('evalSalida').classList.remove('muted'); return; }
-    const op=calcOpMarginPct(m,r,re); const cumple=(op+1e-9>=o)?'✅ CUMPLE':'➡️ NO cumple';
-    $('evalSalida').innerHTML=`Con compra a <b>${fmt(re)}</b>, margen operativo: <b>${op.toFixed(2)}%</b><br>${cumple} el mínimo requerido de ${o.toFixed(2)}%.`; $('evalSalida').classList.remove('muted');
+    const m=parseNum($('margen').value), r=parseNum($('cobro').value), o=parseNum($('operativo').value), re=parseNum($('eval').value), out=$('evalSalida');
+    out.classList.remove('muted','success','error');
+    if(!isFinite(re)||re<=0){ out.innerHTML='⚠️ Ingresa una tasa de compra válida.'; out.classList.add('error'); return; }
+    const op=calcOpMarginPct(m,r,re); const cumple=(op+1e-9>=o);
+    out.innerHTML=`Con compra a <b>${fmt(re)}</b>, margen operativo: <b>${op.toFixed(2)}%</b><br>${cumple?'✅ CUMPLE':'➡️ NO cumple'} el mínimo requerido de ${o.toFixed(2)}%.`; out.classList.add(cumple?'success':'error');
   });
   if('serviceWorker' in navigator){ window.addEventListener('load', ()=>{ navigator.serviceWorker.register('./service-worker.js'); }); }
 })();

--- a/index.html
+++ b/index.html
@@ -17,33 +17,53 @@
     <h1>Calculadora de Tasa Máxima de Compra</h1>
   </header>
 
+  <section class="intro">
+    <p>Herramienta para determinar la tasa m&aacute;xima a la que puedes comprar divisas sin
+      afectar el margen operativo deseado. Introduce el margen bruto, la tasa a la que
+      cobras al cliente y el margen operativo m&iacute;nimo. Por ejemplo, con un margen del
+      40&#37; y una tasa de cobro de 149.44 Bs/USD, obtendr&aacute;s la tasa de compra m&aacute;xima
+      que mantiene tus objetivos.</p>
+  </section>
+
   <main class="container">
     <section class="card">
       <h2>Parámetros</h2>
 
-      <label class="label" for="margen">Margen de ganancia sobre la venta (%)</label>
+      <label class="label" for="margen">Margen de ganancia sobre la venta (%)
+        <span class="info" title="Porcentaje de ganancia que aplicas al precio de venta">ℹ️</span>
+      </label>
       <input id="margen" type="number" inputmode="decimal" placeholder="Ej: 40" value="40" />
 
-      <label class="label" for="cobro">Tasa a la que COBRAS al cliente (Bs/USD)</label>
+      <label class="label" for="cobro">Tasa a la que COBRAS al cliente (Bs/USD)
+        <span class="info" title="Tipo de cambio facturado al cliente en bolívares por dólar">ℹ️</span>
+      </label>
       <input id="cobro" type="number" inputmode="decimal" placeholder="Ej: 149.44" value="149.44" />
 
-      <label class="label" for="operativo">Mínimo % de ganancia OPERATIVA sobre la venta</label>
+      <label class="label" for="operativo">Mínimo % de ganancia OPERATIVA sobre la venta
+        <span class="info" title="Utilidad neta deseada tras costos operativos">ℹ️</span>
+      </label>
       <input id="operativo" type="number" inputmode="decimal" placeholder="Ej: 10" value="10" />
 
       <button id="btnCalcular">Calcular tasa MÁXIMA de COMPRA</button>
-
-      <div id="resultado" class="result muted">—</div>
+      <div class="output">
+        <h3>Resultado</h3>
+        <div id="resultado" class="result muted">—</div>
+      </div>
     </section>
 
     <section class="card">
       <h2>Evaluar una TASA DE COMPRA</h2>
 
-      <label class="label" for="eval">Tasa de COMPRA a evaluar (Bs/USD)</label>
+      <label class="label" for="eval">Tasa de COMPRA a evaluar (Bs/USD)
+        <span class="info" title="Tasa de compra que deseas analizar">ℹ️</span>
+      </label>
       <input id="eval" type="number" inputmode="decimal" placeholder="Ej: 220" />
 
       <button id="btnEvaluar">Evaluar</button>
-
-      <div id="evalSalida" class="result muted">—</div>
+      <div class="output">
+        <h3>Evaluación</h3>
+        <div id="evalSalida" class="result muted">—</div>
+      </div>
     </section>
 
     <footer class="footer">

--- a/styles.css
+++ b/styles.css
@@ -1,17 +1,33 @@
-:root{--bg:#f6f7fb;--card:#fff;--text:#0f172a;--muted:#64748b;--accent:#2563eb;--radius:16px;--shadow:0 6px 20px rgba(2,6,23,.08)}
+:root{
+  --bg:#f6f7fb;
+  --card:#fff;
+  --text:#0f172a;
+  --muted:#64748b;
+  --accent:#2563eb;
+  --success:#16a34a;
+  --error:#dc2626;
+  --radius:16px;
+  --shadow:0 6px 20px rgba(2,6,23,.08)
+}
 *{box-sizing:border-box}html,body{height:100%}
 body{margin:0;font:16px/1.4 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:var(--text);background:var(--bg)}
 .app-header{position:sticky;top:0;z-index:10;background:linear-gradient(180deg,#0f172a,#111827);color:#fff;padding:calc(env(safe-area-inset-top,0px)+14px) 16px 14px;text-align:center;box-shadow:var(--shadow)}
 .app-header h1{font-size:18px;margin:0}
+.intro{max-width:720px;margin:16px auto;padding:0 16px;color:var(--text)}
 .container{max-width:720px;margin:16px auto;padding:0 16px 40px}
-.card{background:var(--card);border-radius:var(--radius);box-shadow:var(--shadow);padding:18px;margin-bottom:16px}
+.card{background:var(--card);border-radius:var(--radius);box-shadow:var(--shadow);padding:20px;margin-bottom:20px}
 .card h2{font-size:16px;margin:0 0 8px 0}
 .label{display:block;margin:10px 0 6px;color:var(--muted);font-size:14px}
-input{width:100%;border:1px solid #e5e7eb;border-radius:12px;padding:12px 14px;font-size:16px;outline:none;background:#fff}
+input{width:100%;border:1px solid #e5e7eb;border-radius:12px;padding:12px 14px;font-size:16px;outline:none;background:#fff;transition:border-color .2s,box-shadow .2s}
 input:focus{border-color:#93c5fd;box-shadow:0 0 0 3px rgba(37,99,235,.15)}
-button{margin-top:14px;width:100%;border:0;border-radius:14px;padding:12px 14px;background:var(--accent);color:#fff;font-weight:600;font-size:16px;box-shadow:0 8px 18px rgba(37,99,235,.25);cursor:pointer}
+button{margin-top:14px;width:100%;border:0;border-radius:14px;padding:12px 14px;background:var(--accent);color:#fff;font-weight:600;font-size:16px;box-shadow:0 8px 18px rgba(37,99,235,.25);cursor:pointer;transition:background-color .2s,box-shadow .2s,transform .1s}
+button:hover{background:#1d4ed8}
 button:active{transform:translateY(1px)}
-.result{margin-top:12px;padding:12px 14px;border-radius:12px;background:#f1f5f9}
+.info{margin-left:4px;cursor:help;color:var(--accent)}
+.output{margin-top:14px}
+.result{margin-top:12px;padding:12px 14px;border-radius:12px;background:#f1f5f9;transition:background-color .2s,color .2s}
+.result.success{background:#dcfce7;color:var(--success)}
+.result.error{background:#fee2e2;color:var(--error)}
 .muted{color:var(--muted)}
 .footer{margin:16px 0 40px;text-align:center;color:var(--muted)}
 .footer small{font-size:12px}


### PR DESCRIPTION
## Summary
- add intro section and tooltips explaining parameters
- wrap results with headings and style feedback as success or error
- refresh styles with color palette, spacing tweaks, and smooth transitions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b99f3e7bf8832399e0ea11ec6ea144