### PR TITLE
Improve form validation for missing inputs

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,7 +7,8 @@
   $('btnCalcular').addEventListener('click', ()=>{
     const m=parseNum($('margen').value), r=parseNum($('cobro').value), o=parseNum($('operativo').value), res=$('resultado');
     res.classList.remove('muted','success','error');
-    if(!isFinite(m)||!isFinite(r)||!isFinite(o)||r<=0||m<0||m>=100||o<0||o>=100){ res.innerHTML='⚠️ Revisa los valores (números válidos, % entre 0–100, tasa > 0).'; res.classList.add('error'); return; }
+    if(!isFinite(m)||!isFinite(r)||!isFinite(o)){ res.innerHTML='⚠️ Ingresa margen, tasa de cobro y margen operativo.'; res.classList.add('error'); return; }
+    if(r<=0||m<0||m>=100||o<0||o>=100){ res.innerHTML='⚠️ Revisa los valores (números válidos, % entre 0–100, tasa > 0).'; res.classList.add('error'); return; }
     if(m + 1e-12 < o){ res.innerHTML=`❌ Imposible: margen bruto ${m.toFixed(2)}% < mínimo operativo ${o.toFixed(2)}%.`; res.classList.add('error'); return; }
     const rmax=calcRCompraMax(m,r,o); if(!isFinite(rmax)){ res.innerHTML='⚠️ Parámetros inválidos (1 - m + o ≤ 0).'; res.classList.add('error'); return; }
     res.innerHTML=`Tasa <b>MÁXIMA</b> de <b>COMPRA</b>: <b>${fmt(rmax)} Bs/USD</b><br>Si compras al mismo tipo que cobras (${fmt(r)}), tu margen operativo = margen bruto: ${m.toFixed(2)}%.`; res.classList.add('success');
@@ -15,6 +16,7 @@
   $('btnEvaluar').addEventListener('click', ()=>{
     const m=parseNum($('margen').value), r=parseNum($('cobro').value), o=parseNum($('operativo').value), re=parseNum($('eval').value), out=$('evalSalida');
     out.classList.remove('muted','success','error');
+    if(!isFinite(m)||!isFinite(r)||!isFinite(o)){ out.innerHTML='⚠️ Completa los parámetros iniciales antes de evaluar.'; out.classList.add('error'); return; }
     if(!isFinite(re)||re<=0){ out.innerHTML='⚠️ Ingresa una tasa de compra válida.'; out.classList.add('error'); return; }
     const op=calcOpMarginPct(m,r,re); const cumple=(op+1e-9>=o);
     out.innerHTML=`Con compra a <b>${fmt(re)}</b>, margen operativo: <b>${op.toFixed(2)}%</b><br>${cumple?'✅ CUMPLE':'➡️ NO cumple'} el mínimo requerido de ${o.toFixed(2)}%.`; out.classList.add(cumple?'success':'error');

--- a/index.html
+++ b/index.html
@@ -32,17 +32,17 @@
       <label class="label" for="margen">Margen de ganancia sobre la venta (%)
         <span class="info" title="Porcentaje de ganancia que aplicas al precio de venta">ℹ️</span>
       </label>
-      <input id="margen" type="number" inputmode="decimal" placeholder="Ej: 40" value="40" />
+      <input id="margen" type="number" inputmode="decimal" placeholder="Ej: 40" />
 
       <label class="label" for="cobro">Tasa a la que COBRAS al cliente (Bs/USD)
         <span class="info" title="Tipo de cambio facturado al cliente en bolívares por dólar">ℹ️</span>
       </label>
-      <input id="cobro" type="number" inputmode="decimal" placeholder="Ej: 149.44" value="149.44" />
+      <input id="cobro" type="number" inputmode="decimal" placeholder="Ej: 149.44" />
 
       <label class="label" for="operativo">Mínimo % de ganancia OPERATIVA sobre la venta
         <span class="info" title="Utilidad neta deseada tras costos operativos">ℹ️</span>
       </label>
-      <input id="operativo" type="number" inputmode="decimal" placeholder="Ej: 10" value="10" />
+      <input id="operativo" type="number" inputmode="decimal" placeholder="Ej: 10" />
 
       <button id="btnCalcular">Calcular tasa MÁXIMA de COMPRA</button>
       <div class="output">


### PR DESCRIPTION
## Summary
- Remove default values from margin, charge and operating inputs
- Add checks in app.js to warn when required inputs are missing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a2f3fe5c8323bfb3c73d89bc552f