### PR TITLE
Adjust PWA install banner and disable caching

### DIFF
--- a/app.js
+++ b/app.js
@@ -41,13 +41,17 @@
   });
 
   installBtn.addEventListener('click', async ()=>{
-    if(deferredPrompt){
-      deferredPrompt.prompt();
-      await deferredPrompt.userChoice;
-      deferredPrompt=null;
-    }
+    if(!deferredPrompt) return;
+    deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    deferredPrompt=null;
     banner.hidden=true;
   });
 
   dismissBtn.addEventListener('click', ()=>{ banner.hidden=true; });
+
+  window.addEventListener('appinstalled', () => {
+    banner.hidden = true;
+    deferredPrompt = null;
+  });
 })();

--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#60a5fa" />
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="Calculadora Tasa">

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,1 +1,19 @@
-const CACHE_NAME='tasa-pwa-v1'; const ASSETS=['./','./index.html','./styles.css','./app.js','./manifest.webmanifest','./assets/icon-192.png','./assets/icon-512.png','./assets/maskable-512.png','./assets/apple-touch-icon-180.png']; self.addEventListener('install',e=>{e.waitUntil(caches.open(CACHE_NAME).then(c=>c.addAll(ASSETS)))}); self.addEventListener('activate',e=>{e.waitUntil(caches.keys().then(keys=>Promise.all(keys.map(k=>k===CACHE_NAME?null:caches.delete(k))))) }); self.addEventListener('fetch',e=>{const req=e.request; e.respondWith(caches.match(req).then(res=>res||fetch(req))) });
+const CACHE_NAME = 'tasa-pwa-v2';
+
+self.addEventListener('install', (event) => {
+  // Activate new service worker immediately
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  // Remove any previously cached data
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(keys.map(key => caches.delete(key))))
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  // Always fetch from network to avoid stale caches
+  event.respondWith(fetch(event.request));
+});

--- a/styles.css
+++ b/styles.css
@@ -56,7 +56,7 @@ body{
   min-height:100vh;
   display:flex;
   flex-direction:column;
-  padding:calc(env(safe-area-inset-top)+72px) 16px calc(env(safe-area-inset-bottom)+120px)
+  padding:calc(env(safe-area-inset-top)+96px) 16px calc(env(safe-area-inset-bottom)+120px)
 }
 .card{
   background:var(--card);
@@ -122,7 +122,7 @@ button:active{box-shadow:0 1px 3px rgba(37,99,235,.3)}
 .install-banner{
   position:fixed;
   left:50%;
-  bottom:calc(env(safe-area-inset-bottom)+56px);
+  bottom:calc(env(safe-area-inset-bottom)+80px);
   transform:translateX(-50%);
   background:var(--card);
   color:var(--text);
@@ -131,7 +131,11 @@ button:active{box-shadow:0 1px 3px rgba(37,99,235,.3)}
   padding:12px 16px;
   display:flex;
   align-items:center;
+  justify-content:center;
+  flex-wrap:wrap;
   gap:8px;
+  max-width:calc(100% - 32px);
+  text-align:center;
 }
 .install-banner button{
   width:auto;


### PR DESCRIPTION
## Summary
- Increase top padding to avoid overlap with header and improve install banner layout
- Add no-cache headers and service worker logic to always fetch latest files
- Harden PWA install flow and hide banner after app installation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b0831adc8323ba9092e898b96900