### PR TITLE
Prevent search engine caching

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,8 @@
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
   <meta http-equiv="Pragma" content="no-cache" />
   <meta http-equiv="Expires" content="0" />
+  <meta name="robots" content="noindex, nofollow, noarchive" />
+  <meta name="googlebot" content="noindex, nofollow, noarchive" />
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="Calculadora Tasa">

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## Summary
- add robots meta tags to stop indexing and cached copies
- block crawlers with a robots.txt

## Testing
- `npx --yes htmlhint index.html` (fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)
- `npm test` (fails: ENOENT: no such file or directory, open 'package.json')

------
https://chatgpt.com/codex/tasks/task_e_68bc2aca74988323b302d6c47d70ff57