### PR TITLE
Fix safe-area padding fallback for container

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -56,7 +56,8 @@ body{
   min-height:100vh;
   display:flex;
   flex-direction:column;
-  padding:calc(env(safe-area-inset-top)+96px) 16px calc(env(safe-area-inset-bottom)+120px)
+  padding:96px 16px 120px;
+  padding:calc(env(safe-area-inset-top) + 96px) 16px calc(env(safe-area-inset-bottom) + 120px);
 }
 .tabs{
   display:flex;


### PR DESCRIPTION
## Summary
- add a static padding fallback for the container and format the safe-area padding with calc spacing

## Testing
- manual verification in desktop and mobile viewports

------
https://chatgpt.com/codex/tasks/task_e_68caa98ddf0c83238355c0d331462e92