### PR TITLE
Add access gate and logging for calculator

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,10 +1,275 @@
 (function(){
+  const SECRET_KEY = 'bowe';
+  const AUTH_SESSION_KEY = 'calc.access.authorized';
+  const LOG_STORAGE_KEY = 'calc.access.logs';
+  const SESSION_ID_KEY = 'calc.access.session';
+  const UNKNOWN_IP = 'Desconocida';
+  const MAX_LOGS = 500;
+
   const $ = (id)=>document.getElementById(id);
   const fmt = (n)=>Number(n).toLocaleString('es-VE',{minimumFractionDigits:4, maximumFractionDigits:4});
   const fmt2 = (n)=>Number(n).toLocaleString('es-VE',{minimumFractionDigits:2, maximumFractionDigits:2});
   function parseNum(v){ if(v==null) return NaN; const s=String(v).trim().replace(',', '.').replace(/[^\d.\-]/g,''); return s?Number(s):NaN; }
   function calcRCompraMax(m_pct, r_cobro, o_pct){ const m=m_pct/100, o=o_pct/100; const denom=1-m+o; if(denom<=0) return NaN; return r_cobro/denom; }
   function calcOpMarginPct(m_pct, r_cobro, r_compra){ const m=m_pct/100; return (r_cobro/r_compra - (1-m)) * 100; }
+  function detectDeviceType(){
+    const ua = navigator.userAgent || '';
+    const isIpad = /ipad/i.test(ua) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+    if(isIpad || /tablet/i.test(ua)){ return 'tablet'; }
+    if(/mobile|iphone|android|ipod/i.test(ua)){ return 'móvil'; }
+    return 'escritorio';
+  }
+  function gatherEnvironment(){
+    const languages = navigator.languages ? Array.from(navigator.languages) : (navigator.language ? [navigator.language] : []);
+    const info = {
+      userAgent: navigator.userAgent || 'Desconocido',
+      language: navigator.language || 'Desconocido',
+      languages,
+      platform: navigator.platform || 'Desconocido',
+      vendor: navigator.vendor || 'Desconocido',
+      deviceType: detectDeviceType(),
+      screenSize: (typeof screen !== 'undefined') ? `${screen.width}x${screen.height}` : 'Desconocida',
+      colorDepth: (typeof screen !== 'undefined') ? screen.colorDepth : undefined,
+      timezone: (()=>{ try{ return Intl.DateTimeFormat().resolvedOptions().timeZone; }catch(_){ return 'Desconocida'; } })(),
+      referrer: document.referrer || '',
+      cookiesEnabled: navigator.cookieEnabled,
+      online: navigator.onLine,
+      hardwareConcurrency: navigator.hardwareConcurrency || null,
+      deviceMemory: navigator.deviceMemory || null,
+      touchPoints: navigator.maxTouchPoints || 0,
+      doNotTrack: navigator.doNotTrack || null,
+      viewport: (typeof window !== 'undefined') ? `${window.innerWidth}x${window.innerHeight}` : 'Desconocido'
+    };
+    if(navigator.connection){
+      info.connection = {
+        effectiveType: navigator.connection.effectiveType,
+        downlink: navigator.connection.downlink,
+        rtt: navigator.connection.rtt,
+        saveData: navigator.connection.saveData
+      };
+    }
+    return info;
+  }
+  function ensureSessionId(){
+    try{
+      const stored = sessionStorage.getItem(SESSION_ID_KEY);
+      if(stored){ return stored; }
+      const generated = (typeof crypto !== 'undefined' && crypto.randomUUID) ? crypto.randomUUID() : `${Date.now()}-${Math.random().toString(36).slice(2,10)}`;
+      sessionStorage.setItem(SESSION_ID_KEY, generated);
+      return generated;
+    }catch(_){
+      return `${Date.now()}-${Math.random().toString(36).slice(2,10)}`;
+    }
+  }
+  const sessionId = ensureSessionId();
+  const baseInfo = Object.assign({ sessionId, url: location.href }, gatherEnvironment());
+  let ipInfo = { ip: UNKNOWN_IP, source: 'pendiente' };
+
+  const accessGate = $('accessGate');
+  const accessForm = $('accessForm');
+  const accessInput = $('accessKey');
+  const accessMessage = $('accessMessage');
+  const appMain = $('appMain');
+
+  function loadLogs(){
+    try{
+      const stored = localStorage.getItem(LOG_STORAGE_KEY);
+      if(!stored){ return []; }
+      const parsed = JSON.parse(stored);
+      return Array.isArray(parsed) ? parsed : [];
+    }catch(err){
+      console.warn('No fue posible leer los registros de acceso.', err);
+      return [];
+    }
+  }
+  function saveLogs(logs){
+    try{
+      if(logs.length > MAX_LOGS){ logs.splice(0, logs.length - MAX_LOGS); }
+      localStorage.setItem(LOG_STORAGE_KEY, JSON.stringify(logs));
+    }catch(err){
+      console.warn('No fue posible guardar el registro de acceso.', err);
+    }
+  }
+  function logEvent(event, extra = {}){
+    const entry = Object.assign({
+      timestamp: new Date().toISOString(),
+      event,
+      ip: ipInfo.ip,
+      ipDetails: Object.assign({}, ipInfo)
+    }, baseInfo, extra);
+    if(Array.isArray(entry.languages)){ entry.languages = entry.languages.slice(); }
+    if(entry.connection){ entry.connection = Object.assign({}, entry.connection); }
+    const logs = loadLogs();
+    logs.push(entry);
+    saveLogs(logs);
+    if(typeof console !== 'undefined' && console){
+      const logger = console.debug ? 'debug' : 'log';
+      console[logger]('[Registro acceso]', entry);
+    }
+  }
+  function updateStoredLogsWithIp(){
+    if(!ipInfo || !ipInfo.ip || ipInfo.ip === UNKNOWN_IP){ return; }
+    try{
+      const stored = localStorage.getItem(LOG_STORAGE_KEY);
+      if(!stored){ return; }
+      const logs = JSON.parse(stored);
+      if(!Array.isArray(logs)){ return; }
+      let modified = false;
+      for(const entry of logs){
+        if(entry && entry.sessionId === sessionId && (entry.ip === UNKNOWN_IP || (entry.ipDetails && entry.ipDetails.ip === UNKNOWN_IP))){
+          entry.ip = ipInfo.ip;
+          entry.ipDetails = Object.assign({}, ipInfo);
+          modified = true;
+        }
+      }
+      if(modified){
+        localStorage.setItem(LOG_STORAGE_KEY, JSON.stringify(logs));
+      }
+    }catch(err){
+      console.warn('No fue posible actualizar los registros con la IP obtenida.', err);
+    }
+  }
+  function scheduleFocus(el){ if(el){ setTimeout(()=>{ try{ el.focus(); if(typeof el.select === 'function'){ el.select(); } }catch(_){/* noop */} }, 60); } }
+  function showApp(){
+    if(appMain){
+      appMain.hidden = false;
+      appMain.setAttribute('aria-hidden','false');
+    }
+    if(accessGate){
+      accessGate.hidden = true;
+      accessGate.setAttribute('aria-hidden','true');
+    }
+    if(document.body){ document.body.classList.remove('locked'); }
+  }
+  function showGate(){
+    if(appMain){
+      appMain.hidden = true;
+      appMain.setAttribute('aria-hidden','true');
+    }
+    if(accessGate){
+      accessGate.hidden = false;
+      accessGate.setAttribute('aria-hidden','false');
+    }
+    if(accessMessage){
+      accessMessage.textContent='';
+      accessMessage.classList.remove('success','error');
+    }
+    if(document.body){ document.body.classList.add('locked'); }
+    scheduleFocus(accessInput);
+  }
+  function initAccessControl(){
+    if(!accessGate || !accessForm || !accessInput || !appMain){
+      showApp();
+      logEvent('access_control_error', { message: 'No se encontró la interfaz completa de control de acceso.' });
+      return;
+    }
+    const authorized = sessionStorage.getItem(AUTH_SESSION_KEY) === 'true';
+    if(authorized){
+      showApp();
+      logEvent('access_restored', { source: 'sessionStorage' });
+    }else{
+      showGate();
+      logEvent('gate_displayed', { source: 'initial_load' });
+    }
+    accessForm.addEventListener('submit', (event)=>{
+      event.preventDefault();
+      const attemptRaw = accessInput.value;
+      const attempt = attemptRaw.trim();
+      const success = attempt === SECRET_KEY;
+      const details = {
+        keyAttempt: attempt,
+        keyLength: attempt.length,
+        status: success ? 'success' : 'failure',
+        source: 'form'
+      };
+      logEvent('access_attempt', details);
+      if(success){
+        sessionStorage.setItem(AUTH_SESSION_KEY, 'true');
+        showApp();
+        accessForm.reset();
+        if(accessMessage){
+          accessMessage.textContent='Acceso concedido.';
+          accessMessage.classList.remove('error');
+          accessMessage.classList.add('success');
+        }
+        logEvent('access_granted', { keyUsed: attempt, method: 'manual' });
+        setTimeout(()=>{
+          if(accessMessage){
+            accessMessage.textContent='';
+            accessMessage.classList.remove('success');
+          }
+        }, 2000);
+      }else{
+        if(accessMessage){
+          accessMessage.textContent='Clave incorrecta. Inténtalo de nuevo.';
+          accessMessage.classList.remove('success');
+          accessMessage.classList.add('error');
+        }
+        scheduleFocus(accessInput);
+      }
+    });
+  }
+  function fetchIpDetails(){
+    function applyInfo(info){
+      ipInfo = Object.assign({ ip: UNKNOWN_IP }, info);
+      updateStoredLogsWithIp();
+      if(info.source && info.source !== 'unavailable'){
+        logEvent('ip_obtained', {
+          provider: info.source,
+          ip: ipInfo.ip,
+          city: ipInfo.city || '',
+          region: ipInfo.region || '',
+          country: ipInfo.country || '',
+          latitude: ipInfo.latitude,
+          longitude: ipInfo.longitude
+        });
+      }
+    }
+    return fetch('https://ipapi.co/json/')
+      .then((response)=>{
+        if(!response.ok){ throw new Error('Respuesta inválida'); }
+        return response.json();
+      })
+      .then((data)=>{
+        applyInfo({
+          ip: data.ip || UNKNOWN_IP,
+          city: data.city || '',
+          region: data.region || '',
+          country: data.country_name || data.country || '',
+          latitude: data.latitude,
+          longitude: data.longitude,
+          postal: data.postal || '',
+          org: data.org || '',
+          timezone: data.timezone || '',
+          source: 'ipapi.co'
+        });
+      })
+      .catch(()=>{
+        return fetch('https://api.ipify.org?format=json')
+          .then((response)=>{
+            if(!response.ok){ throw new Error('Respuesta inválida'); }
+            return response.json();
+          })
+          .then((data)=>{
+            applyInfo({
+              ip: data.ip || UNKNOWN_IP,
+              source: 'api.ipify.org'
+            });
+          })
+          .catch((error)=>{
+            console.warn('No fue posible obtener la IP del visitante.', error);
+            applyInfo({ source: 'unavailable' });
+          });
+      })
+      .finally(()=>{
+        updateStoredLogsWithIp();
+        logEvent('visit', { detail: 'initial_load' });
+      });
+  }
+
+  fetchIpDetails();
+  initAccessControl();
+
   $('btnCalcular').addEventListener('click', ()=>{
     const m=parseNum($('margen').value), r=parseNum($('cobro').value), o=parseNum($('operativo').value), res=$('resultado');
     res.classList.remove('muted','success','error');
@@ -43,7 +308,6 @@
       });
     });
   });
-
   $('btnPromedio').addEventListener('click', ()=>{
     const montoBcv=parseNum($('montoBcv').value), tasaBcv=parseNum($('tasaBcv').value);
     const montoAlt=parseNum($('montoAlt').value), tasaAlt=parseNum($('tasaAlt').value);
@@ -75,6 +339,5 @@
     res.innerHTML=`Total comprado: <b>${fmt2(totalUsd)} USD</b><br>Total pagado: <b>${fmt2(totalBs)} Bs</b><br>Tasa promedio ponderada: <b>${fmt(promedio)} Bs/USD</b>`;
     res.classList.add('success');
   });
-
   if('serviceWorker' in navigator){ window.addEventListener('load', ()=>{ navigator.serviceWorker.register('./service-worker.js'); }); }
 })();

--- a/index.html
+++ b/index.html
@@ -18,12 +18,24 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+  <div id="accessGate" class="access-gate" role="dialog" aria-modal="true" aria-labelledby="accessTitle">
+    <div class="gate-card">
+      <h2 id="accessTitle">Acceso restringido</h2>
+      <p class="gate-intro">Introduce la clave secreta para continuar. Las visitas quedan registradas para control interno.</p>
+      <form id="accessForm" autocomplete="off">
+        <label class="label" for="accessKey">Clave secreta</label>
+        <input id="accessKey" name="accessKey" type="password" inputmode="text" autocomplete="off" autocapitalize="off" spellcheck="false" required />
+        <button type="submit">Ingresar</button>
+      </form>
+      <p id="accessMessage" class="access-message" aria-live="polite"></p>
+    </div>
+  </div>
   <header class="app-header">
     <h1>Calculadora de Tasa Máxima de Compra</h1>
     <a href="#ayuda" class="help-btn" aria-label="Ayuda">?</a>
   </header>
 
-  <main class="container">
+  <main id="appMain" class="container" hidden aria-hidden="true">
     <div class="tabs" role="tablist">
       <button id="tab-max" class="tab active" type="button" role="tab" aria-selected="true" aria-controls="panel-max" data-target="panel-max">Tasa máxima</button>
       <button id="tab-promedio" class="tab" type="button" role="tab" aria-selected="false" aria-controls="panel-promedio" data-target="panel-promedio">Promedio de compra</button>

--- a/styles.css
+++ b/styles.css
@@ -19,6 +19,33 @@ body{
   display:flex;
   flex-direction:column
 }
+body.locked{overflow:hidden}
+.access-gate{
+  position:fixed;
+  inset:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:32px 16px;
+  background:linear-gradient(135deg,rgba(96,165,250,.9),rgba(59,130,246,.85));
+  backdrop-filter:blur(2px);
+  z-index:1000
+}
+.access-gate[hidden]{display:none}
+.gate-card{
+  width:100%;
+  max-width:360px;
+  background:var(--card);
+  border-radius:var(--radius);
+  box-shadow:var(--shadow);
+  padding:24px;
+  text-align:center
+}
+.gate-card h2{margin:0 0 12px;font-size:20px}
+.gate-intro{margin:0 0 16px;color:var(--muted);font-size:14px}
+.access-message{margin-top:16px;font-size:14px;min-height:20px}
+.access-message.success{color:var(--success)}
+.access-message.error{color:var(--error)}
 .app-header{
   position:fixed;
   top:0;left:0;right:0;


### PR DESCRIPTION
## Summary
- add a full screen gate that requests the temporary secret key before showing the calculator UI
- log visits and access attempts with IP/device metadata in local storage for traceability
- update markup and styles to support the gate overlay while keeping the existing calculator intact

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d33602de808323b8623a78d31d9793